### PR TITLE
feat: add fuel quote history page

### DIFF
--- a/src/app/fuel/history/loading.tsx
+++ b/src/app/fuel/history/loading.tsx
@@ -1,0 +1,5 @@
+import LoadingSpinner from "@/components/loading/LoadingSpinner";
+
+export default function Loading() {
+	return <LoadingSpinner />;
+}

--- a/src/app/fuel/history/page.tsx
+++ b/src/app/fuel/history/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+export default function Page() {
+	const fuelQuoteHistory = [{
+		gallonsRequested: 100,
+		deliveryAddress: "1234 Main St, Houston, TX 77001 1234 Main St, Houston",
+		deliveryDate: "01/01/2021",
+		suggestedPrice: "$150.00"
+	}, {
+		gallonsRequested: 120,
+		deliveryAddress: "1234 Main St, Houston, TX 77001",
+		deliveryDate: "01/05/2021",
+		suggestedPrice: "$200.00"
+	}];
+	
+	return (
+		<div className="text-neutral-200 p-12">
+			<h1 className="text-3xl font-semibold text-neutral-100 pb-16">Fuel Quote History</h1>
+
+			<table className="text-neutral-400 text-sm font-medium leading-6 w-full border border-inputBorder">
+				<thead className="bg-[#2E2E2E]">
+					<tr>
+						<th className="border-r border-inputBorder">Gallons Requested</th>
+						<th className="border-r border-inputBorder">Delivery Address</th>
+						<th className="border-r border-inputBorder">Delivery Date</th>
+						<th className="border-r border-inputBorder">Suggested Price</th>
+					</tr>
+				</thead>
+				<tbody className="text-center">
+					{fuelQuoteHistory.map((quote, index) => (
+
+					<tr className="border-b border-inputBorder">
+						<td className="border-r border-inputBorder">{quote.gallonsRequested}</td>
+						<td className="border-r border-inputBorder">{quote.deliveryAddress}</td>
+						<td className="border-r border-inputBorder">{quote.deliveryDate}</td>
+						<td className="border-r border-inputBorder">{quote.suggestedPrice}</td>
+					</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}


### PR DESCRIPTION
### Notes
- Add fuel quote history page 
   - Tabular display of all client quotes in the past. All fields from Fuel Quote are displayed.
   - Add loading spinner when page is loading
   - Add mock data to table

### Screenshots
<img width="1498" alt="Screen Shot 2024-02-21 at 12 09 04 PM" src="https://github.com/Team-We-are-Cooking/fueltility/assets/91701930/4c512288-bc51-4972-9b97-ef9b69acf189">
